### PR TITLE
Allow for filtering of Blade engine function

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Extend from this class to register a vanilla PHP template.
 
 If your project uses the [Sage](https://roots.io/sage) theme, you can take advantage of Blade templating by extending from this class (in future, [Sage](https://roots.io/sage) will be optional).
 
+The `isValid` method will look for `\App\template`. If you're in a Sage environment where that doesn't exist (i.e. Sage 10), you can use the `acf_gutenblocks/blade_engine_callable` filter to return a different callable. 
+
+```php
+add_filter('acf_gutenblocks/blade_engine_callable', function($callable) { return '\Roots\view'; });
+```
+
 ## Controller
 
 Your Block constructor class is available to your template via `$controller`. This allows you to create truly advanced Blocks by organising all of your functional code and logic into a place where you can take more advantage of an OOP approach.

--- a/src/AbstractBladeBlock.php
+++ b/src/AbstractBladeBlock.php
@@ -13,7 +13,7 @@ abstract class AbstractBladeBlock extends Block implements InitializableInterfac
         return '.blade.php';
     }
 
-    public function getBladeEngineCallable()
+    public function getBladeEngineCallable(): string
     {
         return apply_filters(
             'acf_gutenblocks/blade_engine_callable',

--- a/src/AbstractBladeBlock.php
+++ b/src/AbstractBladeBlock.php
@@ -13,9 +13,19 @@ abstract class AbstractBladeBlock extends Block implements InitializableInterfac
         return '.blade.php';
     }
 
+    public function getBladeEngineCallable()
+    {
+        return apply_filters(
+            'acf_gutenblocks/blade_engine_callable',
+            '\App\template',
+            "{$this->dir}/views/frontend{$this->fileExtension()}",
+            $this
+        );
+    }
+
     public function isValid(): bool
     {
-        return function_exists('\App\template');
+        return function_exists($this->getBladeEngineCallable());
     }
 
     public function renderBlockCallback(array $block): void
@@ -34,7 +44,7 @@ abstract class AbstractBladeBlock extends Block implements InitializableInterfac
         ]);
 
         // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo template($frontend, [
+        echo call_user_func($this->getBladeEngineCallable(), $frontend, [
             'block' => $block,
             'controller' => $this,
         ]);

--- a/src/AbstractBladeBlock.php
+++ b/src/AbstractBladeBlock.php
@@ -44,7 +44,7 @@ abstract class AbstractBladeBlock extends Block implements InitializableInterfac
         ]);
 
         // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo call_user_func($this->getBladeEngineCallable(), $frontend, [
+        echo $this->getBladeEngineCallable()($frontend, [
             'block' => $block,
             'controller' => $this,
         ]);

--- a/src/Util.php
+++ b/src/Util.php
@@ -14,7 +14,7 @@ class Util
     public static function sanitizeHtmlClasses(array $classes): string
     {
         return implode(' ', array_map(function ($class) : string {
-            return sanitize_html_class((string)$class);
+            return sanitize_html_class((string) $class);
         }, $classes));
     }
 }


### PR DESCRIPTION
The actual function or method used to render blade templates can vary;
this allows the user to filter the callable that acf-gutenblocks uses
to verify it *can* render, and to do the actual rendering. If the filter
is not used, then it behaves exactly as it did before (i.e. it uses
\App\template()).