### PR TITLE
Add with() method to Block

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -306,6 +306,15 @@ class Block
         ];
     }
 
+	/**
+	 * Make variables available to the template.
+	 *
+	 * @return array
+	 */
+	public function with(): array
+	{
+		return [];
+	}
 
     public function init(): void
     {


### PR DESCRIPTION
Updated from 0.2.1 to 0.4.0 and ran into fatal errors because my blocks don't define a `with` method.

I propose adding a method to the extendable `Block` class just to be safe.